### PR TITLE
Add initial Promovista skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+frontend/node_modules
+backend/node_modules
+backend/build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Promovista
+
+This repository contains a minimal skeleton for the **Promovista** mobile application described in `context.md`.
+
+## Structure
+
+- **frontend/** – Expo React Native project (TypeScript)
+- **backend/** – placeholder for backend services (Supabase Edge Functions / API)
+
+## Features (Planned)
+
+- SMS OTP authentication via Supabase
+- Campaign marketplace with auto-filtering
+- Proof-of-display camera with AI validation
+- Wallet with points economy and Stripe payments
+- Services marketplace and cash-out flow
+- Admin dashboard and automated reports
+- AR guidance overlay and micro-learning modules
+
+> **Note:** This repository only includes a starter project. You must set up Expo, Supabase and other dependencies locally to get a fully working app.
+
+### Running the App
+
+1. Install dependencies (Expo CLI, Node packages)
+2. From the `frontend` folder run `npm start` to launch the Expo dev server.
+3. Configure backend services (Supabase) according to `context.md` roadmap.
+

--- a/backend/functions/hello.ts
+++ b/backend/functions/hello.ts
@@ -1,0 +1,3 @@
+export const onRequest = async () => {
+  return new Response('Hello from Promovista Edge Function');
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "lib": ["es2017"],
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "build"
+  },
+  "include": ["functions/**/*"]
+}

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,0 +1,30 @@
+{
+  "expo": {
+    "name": "Promovista",
+    "slug": "promovista",
+    "platforms": ["ios", "android"],
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "expo start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.72.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Welcome to Promovista</Text>
+    </View>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- add README explaining planned features
- scaffold React Native frontend
- scaffold backend with example edge function
- add tsconfigs and package manifests

## Testing
- `npm init` (failed to reach registry due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_b_685e843d6d54832bbabe3d487a2fd136