### PR TITLE
Add Promovista React Native skeleton

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import registerRootComponent from 'expo/build/launch/registerRootComponent';
+import App from './src/App';
+
+registerRootComponent(App);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "promovista",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.71.8",
+    "expo-status-bar": "^1.4.4",
+    "supabase-js": "^2.39.4",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  },
+  "devDependencies": {
+    "@types/react": "~18.0.24",
+    "@types/react-native": "~0.71.6",
+    "typescript": "^5.1.6",
+    "jest": "^29.7.0",
+    "@testing-library/react-native": "^12.1.5"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './screens/LoginScreen';
+import CampaignsScreen from './screens/CampaignsScreen';
+import ProofOfDisplayScreen from './screens/ProofOfDisplayScreen';
+import WalletScreen from './screens/WalletScreen';
+import ServicesScreen from './screens/ServicesScreen';
+import AdminScreen from './screens/AdminScreen';
+
+export type RootStackParamList = {
+  Login: undefined;
+  Campaigns: undefined;
+  Proof: undefined;
+  Wallet: undefined;
+  Services: undefined;
+  Admin: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Campaigns" component={CampaignsScreen} />
+        <Stack.Screen name="Proof" component={ProofOfDisplayScreen} />
+        <Stack.Screen name="Wallet" component={WalletScreen} />
+        <Stack.Screen name="Services" component={ServicesScreen} />
+        <Stack.Screen name="Admin" component={AdminScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/screens/AdminScreen.tsx
+++ b/src/screens/AdminScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function AdminScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Admin tools placeholder</Text>
+    </View>
+  );
+}

--- a/src/screens/CampaignsScreen.tsx
+++ b/src/screens/CampaignsScreen.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../App';
+
+const CAMPAIGNS = [
+  { id: '1', title: 'Local Beer Display', points: 50 },
+  { id: '2', title: 'Artisan Chocolate', points: 40 },
+];
+
+export default function CampaignsScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Campaigns'>) {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={CAMPAIGNS}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ marginBottom: 16 }}>
+            <Text style={{ fontWeight: 'bold' }}>{item.title}</Text>
+            <Text>{item.points} pts</Text>
+            <Button title="Accept" onPress={() => navigation.navigate('Proof')} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { supabase } from '../supabaseClient';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../App';
+
+export default function LoginScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Login'>) {
+  const [phone, setPhone] = useState('');
+  const [token, setToken] = useState('');
+  const [step, setStep] = useState<'phone' | 'otp'>('phone');
+
+  const sendOtp = async () => {
+    await supabase.auth.signInWithOtp({ phone });
+    setStep('otp');
+  };
+
+  const verifyOtp = async () => {
+    await supabase.auth.verifyOtp({ phone, token, type: 'sms' });
+    navigation.replace('Campaigns');
+  };
+
+  return (
+    <View style={styles.container}>
+      {step === 'phone' ? (
+        <>
+          <Text>Enter phone number</Text>
+          <TextInput value={phone} onChangeText={setPhone} style={styles.input} keyboardType="phone-pad" />
+          <Button title="Send OTP" onPress={sendOtp} />
+        </>
+      ) : (
+        <>
+          <Text>Enter OTP</Text>
+          <TextInput value={token} onChangeText={setToken} style={styles.input} keyboardType="number-pad" />
+          <Button title="Verify" onPress={verifyOtp} />
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    width: '100%',
+    padding: 8,
+    marginVertical: 8,
+  },
+});

--- a/src/screens/ProofOfDisplayScreen.tsx
+++ b/src/screens/ProofOfDisplayScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../App';
+
+export default function ProofOfDisplayScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Proof'>) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Camera overlay would be here</Text>
+      <Text>ONNX validation stub</Text>
+      <Button title="Submit" onPress={() => navigation.navigate('Wallet')} />
+    </View>
+  );
+}

--- a/src/screens/ServicesScreen.tsx
+++ b/src/screens/ServicesScreen.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, FlatList, Button } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../App';
+
+const SERVICES = [
+  { id: '1', title: 'Website Development', cost: 200 },
+  { id: '2', title: 'ERP Add-on', cost: 150 },
+];
+
+export default function ServicesScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Services'>) {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={SERVICES}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ marginBottom: 16 }}>
+            <Text style={{ fontWeight: 'bold' }}>{item.title}</Text>
+            <Text>{item.cost} pts</Text>
+            <Button title="Request" onPress={() => {}} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/src/screens/WalletScreen.tsx
+++ b/src/screens/WalletScreen.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../App';
+
+export default function WalletScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Wallet'>) {
+  const [points, setPoints] = useState(100);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Points Balance: {points}</Text>
+      <Button title="Buy Points" onPress={() => {}} />
+      <Button title="Services" onPress={() => navigation.navigate('Services')} />
+    </View>
+  );
+}

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["es2017"],
+    "types": ["react", "react-native"],
+    "outDir": "build"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- configure initial package.json and tsconfig
- set up jest config
- add Supabase client stub
- create React Navigation structure
- implement placeholder screens for login, campaigns, proof-of-display, wallet, services, admin

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e843d6d54832bbabe3d487a2fd136